### PR TITLE
Ae 462

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -54,12 +54,18 @@ def printer(comm, node_uuid, settings, httpretty): #pylint: disable=redefined-ou
     url = urljoin(settings.get(["authentise_url"]), "/printer/instance/")
     printer_uri = urljoin(url, "abc-123/")
 
-    printers_payload = {"resources": [{"baud_rate": 250000,
-                                       "port": "/dev/tty.derp",
-                                       "uri": printer_uri}]}
+    printer_payload = {"baud_rate": 250000,
+                       "port": "/dev/tty.derp",
+                       "uri": printer_uri}
+
     httpretty.register_uri(httpretty.GET,
                            url,
-                           body=json.dumps(printers_payload),
+                           body=json.dumps({"resources": [printer_payload]}),
+                           content_type='application/json')
+
+    httpretty.register_uri(httpretty.GET,
+                           printer_uri,
+                           body=json.dumps(printer_payload),
                            content_type='application/json')
 
     return {'uri':printer_uri, 'request_url':url, 'port':'/dev/tty.derp', 'baud_rate':250000}

--- a/conftest.py
+++ b/conftest.py
@@ -56,7 +56,15 @@ def printer(comm, node_uuid, settings, httpretty): #pylint: disable=redefined-ou
 
     printer_payload = {"baud_rate": 250000,
                        "port": "/dev/tty.derp",
-                       "uri": printer_uri}
+                       "uri": printer_uri,
+                       'status': 'ONLINE',
+                       'nozzle_temperature': 185.9,
+                       'current_print': {
+                           'status': 'PRINTING',
+                           'percent_complete': 10.55,
+                           'elapsed': 30,
+                           'remaining': 0.4,
+                       }}
 
     httpretty.register_uri(httpretty.GET,
                            url,

--- a/conftest.py
+++ b/conftest.py
@@ -103,3 +103,39 @@ def httpretty():
     HTTPretty.disable()
     socket.SocketType = old_socket_type
     HTTPretty.reset()
+
+@pytest.fixture
+def assert_almost_equal():
+    def __inner(value_0, value_1, places=4):
+        if value_0 != value_1:
+            value_0 = cut_insignificant_digits_recursively(value_0, places)
+            value_1 = cut_insignificant_digits_recursively(value_1, places)
+        assert value_0 == value_1
+    return __inner
+
+#these fucntions are for very basic asserting almost equal, taken from and answer in
+#http://stackoverflow.com/questions/12136762/assertalmostequal-in-python-unit-test-for-collections-of-floats
+def cut_insignificant_digits(number, places):
+    if not isinstance(number, float):
+        return number
+    number_as_str = str(number)
+    end_of_number = number_as_str.find('.')+places+1
+    if end_of_number > len(number_as_str):
+        return number
+    return float(number_as_str[:end_of_number])
+
+def cut_insignificant_digits_lazy(iterable, places):
+    for obj in iterable:
+        yield cut_insignificant_digits_recursively(obj, places)
+
+def cut_insignificant_digits_recursively(obj, places):
+    t = type(obj)
+    if t == float:
+        return cut_insignificant_digits(obj, places)
+    if t in (list, tuple, set):
+        return t(cut_insignificant_digits_lazy(obj, places))
+    if t == dict:
+        return {cut_insignificant_digits_recursively(key, places):
+                cut_insignificant_digits_recursively(val, places)
+                for key,val in obj.items()}
+    return obj

--- a/conftest.py
+++ b/conftest.py
@@ -71,7 +71,7 @@ def printer(comm, node_uuid, settings, httpretty): #pylint: disable=redefined-ou
     return {'uri':printer_uri, 'request_url':url, 'port':'/dev/tty.derp', 'baud_rate':250000}
 
 @pytest.fixture
-def connect_printer(comm, printer, mocker): #pylint: disable=redefined-outer-name
+def connect_printer(comm, printer, mocker, event_manager): #pylint: disable=redefined-outer-name, unused-argument
     mocker.patch('octoprint_authentise.comm.threading.Thread')
     mocker.patch('octoprint_authentise.comm.RepeatedTimer')
     mocker.patch("octoprint_authentise.comm.helpers.run_client")
@@ -81,6 +81,18 @@ def connect_printer(comm, printer, mocker): #pylint: disable=redefined-outer-nam
 @pytest.fixture
 def node_uuid():
     return uuid.uuid4()
+
+@pytest.fixture
+def event_manager(mocker):
+    manager = mocker.Mock()
+    mocker.patch('octoprint_authentise.comm.eventManager', return_value=manager)
+    return manager
+
+@pytest.fixture
+def set_time(mocker):
+    def __inner(_time):
+        mocker.patch('time.time', return_value=_time)
+    return __inner
 
 @pytest.yield_fixture
 def httpretty():

--- a/conftest.py
+++ b/conftest.py
@@ -62,8 +62,15 @@ def printer(comm, node_uuid, settings, httpretty): #pylint: disable=redefined-ou
                            body=json.dumps(printers_payload),
                            content_type='application/json')
 
-    return {'uri': printer_uri, 'request_url': url}
+    return {'uri':printer_uri, 'request_url':url, 'port':'/dev/tty.derp', 'baud_rate':250000}
 
+@pytest.fixture
+def connect_printer(comm, printer, mocker): #pylint: disable=redefined-outer-name
+    mocker.patch('octoprint_authentise.comm.threading.Thread')
+    mocker.patch('octoprint_authentise.comm.RepeatedTimer')
+    mocker.patch("octoprint_authentise.comm.helpers.run_client")
+
+    comm.connect(port=printer['port'], baudrate=printer['baud_rate'])
 
 @pytest.fixture
 def node_uuid():

--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,7 @@
+import json
 import logging
+import uuid
+from urlparse import urljoin
 
 import httpretty as HTTPretty
 import octoprint.plugin
@@ -43,6 +46,28 @@ def comm(plugin, mocker): #pylint: disable=redefined-outer-name
 
     yield plugin
     plugin.close()
+
+@pytest.fixture
+def printer(comm, node_uuid, settings, httpretty): #pylint: disable=redefined-outer-name
+    comm.node_uuid = node_uuid
+
+    url = urljoin(settings.get(["authentise_url"]), "/printer/instance/")
+    printer_uri = urljoin(url, "abc-123/")
+
+    printers_payload = {"resources": [{"baud_rate": 250000,
+                                       "port": "/dev/tty.derp",
+                                       "uri": printer_uri}]}
+    httpretty.register_uri(httpretty.GET,
+                           url,
+                           body=json.dumps(printers_payload),
+                           content_type='application/json')
+
+    return {'uri': printer_uri, 'request_url': url}
+
+
+@pytest.fixture
+def node_uuid():
+    return uuid.uuid4()
 
 @pytest.yield_fixture
 def httpretty():

--- a/octoprint_authentise/comm.py
+++ b/octoprint_authentise/comm.py
@@ -21,14 +21,14 @@ __license__ = "GNU Affero General Public License http://www.gnu.org/licenses/agp
 __copyright__ = "Copyright (C) 2015 Authentise - Released under terms of the AGPLv3 License"
 
 PRINTER_STATE = {
-    'OFFLINE'           : 0,
-    'CONNECTING'        : 4,
-    'OPERATIONAL'       : 5,
-    'PRINTING'          : 6,
-    'PAUSED'            : 7,
-    'CLOSED'            : 8,
-    'ERROR'             : 9,
-    'CLOSED_WITH_ERROR' : 10,
+    'OFFLINE'           : octoprint.plugin.MachineComPlugin.STATE_NONE,
+    'CONNECTING'        : octoprint.plugin.MachineComPlugin.STATE_CONNECTING,
+    'OPERATIONAL'       : octoprint.plugin.MachineComPlugin.STATE_OPERATIONAL,
+    'PRINTING'          : octoprint.plugin.MachineComPlugin.STATE_PRINTING,
+    'PAUSED'            : octoprint.plugin.MachineComPlugin.STATE_PAUSED,
+    'CLOSED'            : octoprint.plugin.MachineComPlugin.STATE_CLOSED,
+    'ERROR'             : octoprint.plugin.MachineComPlugin.STATE_ERROR,
+    'CLOSED_WITH_ERROR' : octoprint.plugin.MachineComPlugin.STATE_CLOSED_WITH_ERROR,
     }
 PRINTER_STATE_REVERSE = dict((v,k) for k,v in PRINTER_STATE.items())
 
@@ -257,7 +257,7 @@ class MachineCom(octoprint.plugin.MachineComPlugin): #pylint: disable=too-many-i
         return self._state in [ PRINTER_STATE['OPERATIONAL'], PRINTER_STATE['PRINTING'], PRINTER_STATE['PAUSED']]
 
     def isPrinting(self):
-        return self._state == PRINTER_STATE['PRINTING'],
+        return self._state == PRINTER_STATE['PRINTING']
 
     def isStreaming(self):
         return
@@ -489,7 +489,6 @@ class MachineCom(octoprint.plugin.MachineComPlugin): #pylint: disable=too-many-i
                 self._log(errorMsg)
                 self._errorValue = errorMsg
                 self._change_state(PRINTER_STATE['ERROR'])
-                eventManager().fire(Events.ERROR, {"error": self.getErrorString()})
             time.sleep(0.1)
         self._log("Connection closed, closing down monitor")
 

--- a/octoprint_authentise/comm.py
+++ b/octoprint_authentise/comm.py
@@ -529,7 +529,7 @@ class MachineCom(octoprint.plugin.MachineComPlugin): #pylint: disable=too-many-i
         self._callback.on_comm_progress()
 
     def _update_state(self, response_data):
-        if response_data['status'].lower() in ['new', 'online']:
+        if response_data['status'].lower() == 'online':
             if not response_data['current_print'] or response_data['current_print']['status'].lower() == 'new':
                 self._change_state(PRINTER_STATE['OPERATIONAL'])
 

--- a/octoprint_authentise/comm.py
+++ b/octoprint_authentise/comm.py
@@ -220,7 +220,7 @@ class MachineCom(octoprint.plugin.MachineComPlugin): #pylint: disable=too-many-i
                 eventManager().fire(Events.PRINT_STARTED, None)
 
             # It is not easy to tell the difference between an completed print and a cancled print at this point
-            elif new_state == PRINTER_STATE['CONNECTED'] and old_state != PRINTER_STATE['CONNECTING']:
+            elif new_state == PRINTER_STATE['OPERATIONAL'] and old_state != PRINTER_STATE['CONNECTING']:
                 eventManager().fire(Events.PRINT_DONE, None)
 
         elif new_state == PRINTER_STATE['CLOSED']:

--- a/octoprint_authentise/comm.py
+++ b/octoprint_authentise/comm.py
@@ -148,7 +148,7 @@ class MachineCom(octoprint.plugin.MachineComPlugin): #pylint: disable=too-many-i
 
         self._printer_status_timer = RepeatedTimer(
             lambda: comm_helpers.get_interval("temperature", default_value=10.0),
-            self._poll_printer_status,
+            self._update_printer_data,
             run_first=True
         )
         self._printer_status_timer.start()
@@ -493,11 +493,6 @@ class MachineCom(octoprint.plugin.MachineComPlugin): #pylint: disable=too-many-i
             time.sleep(0.1)
         self._log("Connection closed, closing down monitor")
 
-    def _poll_printer_status(self):
-        if self.isOperational():
-            self.sendCommand("M105", cmd_type="temperature_poll")
-        self._update_printer_data()
-
     def _update_printer_data(self):
         if not self._printer_uri:
             return
@@ -526,11 +521,10 @@ class MachineCom(octoprint.plugin.MachineComPlugin): #pylint: disable=too-many-i
 
         if current_print and response_data['current_print']['status'].lower() != 'new':
             self._print_progress = {
-                'percent_complete' : current_print['percent_complete'],
+                'percent_complete' : current_print['percent_complete']/100,
                 'elapsed'          : current_print['elapsed'],
                 'remaining'        : current_print['remaining'],
             }
-
         else:
             self._print_progress = None
         self._callback.on_comm_progress()

--- a/octoprint_authentise/comm.py
+++ b/octoprint_authentise/comm.py
@@ -522,7 +522,7 @@ class MachineCom(octoprint.plugin.MachineComPlugin): #pylint: disable=too-many-i
         self._bed_tempurature = [
                 temps['bed'].get('current') if temps.get('bed') else None,
                 temps['bed'].get('target') if temps.get('bed') else None,
-                ]
+                ] if temps.get('bed') else None
 
         self._callback.on_comm_temperature_update(self._tool_tempuratures, self._bed_tempurature)
 

--- a/octoprint_authentise/comm.py
+++ b/octoprint_authentise/comm.py
@@ -260,7 +260,7 @@ class MachineCom(octoprint.plugin.MachineComPlugin): #pylint: disable=too-many-i
         return self._state == PRINTER_STATE['PRINTING']
 
     def isStreaming(self):
-        return
+        return False
 
     def isPaused(self):
         return self._state == PRINTER_STATE['PAUSED']
@@ -269,13 +269,13 @@ class MachineCom(octoprint.plugin.MachineComPlugin): #pylint: disable=too-many-i
         return self.isPrinting() or self.isPaused()
 
     def isSdReady(self):
-        return
+        return False
 
     def isSdFileSelected(self):
-        return
+        return False
 
     def isSdPrinting(self):
-        return
+        return False
 
     def getSdFiles(self):
         return

--- a/octoprint_authentise/comm.py
+++ b/octoprint_authentise/comm.py
@@ -330,10 +330,10 @@ class MachineCom(octoprint.plugin.MachineComPlugin): #pylint: disable=too-many-i
         self._change_state(PRINTER_STATE['CLOSED'])
 
     def setTemperatureOffset(self, offsets):
-        return
+        pass
 
     def fakeOk(self):
-        return
+        pass
 
     def sendCommand(self, cmd, cmd_type=None, processed=False):
         cmd = cmd.encode('ascii', 'replace')
@@ -342,7 +342,7 @@ class MachineCom(octoprint.plugin.MachineComPlugin): #pylint: disable=too-many-i
             if not cmd:
                 return
 
-        if self.isPrinting() or self.isOperational():
+        if self.isOperational():
             data = {'command': cmd}
             printer_command_url = urlparse.urljoin(self._printer_uri, 'command/')
 

--- a/octoprint_authentise/comm.py
+++ b/octoprint_authentise/comm.py
@@ -300,7 +300,7 @@ class MachineCom(octoprint.plugin.MachineComPlugin): #pylint: disable=too-many-i
     ##~~ external interface
 
     def close(self, isError = False):
-        if self._temperature_timer and isinstance(self._temperature_timer, RepeatedTimer):
+        if self._temperature_timer:
             self._temperature_timer.cancel()
 
         self._monitoring_active = False
@@ -517,6 +517,9 @@ class MachineCom(octoprint.plugin.MachineComPlugin): #pylint: disable=too-many-i
         command_response = response.json()
         self._log('Got response: {}, for command: {}'.format(command_response['response'], command_response['command']))
         return command_response['response']
+
+    def _get_printer_status(self):
+        pass
 
     def _monitor_loop(self):
 

--- a/octoprint_authentise/helpers.py
+++ b/octoprint_authentise/helpers.py
@@ -105,3 +105,8 @@ def create_api_token(settings, cookies, logger):
         logger.error("Error creating api token for user")
 
     return response.status_code, json.loads(response.text)
+
+def session(settings):
+    _session = requests.Session()
+    _session.auth = requests.auth.HTTPBasicAuth(settings.get(['api_key']), settings.get(['api_secret']))
+    return _session

--- a/tests/test_comm.py
+++ b/tests/test_comm.py
@@ -312,4 +312,11 @@ def test_parse_temps(line, expected):
     assert actual == expected
 
 def test_get_printer_status(comm, connect_printer): #pylint: disable=unused-argument
-    comm._update_printer_data()
+    # comm._update_printer_data()
+    pass
+
+def test_change_state():
+    pass
+
+def test_send_command():
+    pass

--- a/tests/test_comm.py
+++ b/tests/test_comm.py
@@ -24,12 +24,7 @@ def test_printer_connect_create_authentise_printer(comm, printer, httpretty, moc
 
     comm.connect(port="1234", baudrate=5678)
 
-    assert comm.isOperational()
-    assert not comm.isBusy()
-    assert not comm.isPrinting()
-    assert not comm.isPaused()
-    assert not comm.isError()
-    assert not comm.isClosedOrError()
+    assert comm.getState() == _comm.PRINTER_STATE['CONNECTING']
     assert comm._printer_uri == printer['uri']
 
 
@@ -48,12 +43,7 @@ def test_printer_connect_get_authentise_printer(comm, printer, httpretty, mocker
 
     comm.connect(port="/dev/tty.derp", baudrate=5678)
 
-    assert comm.isOperational()
-    assert not comm.isBusy()
-    assert not comm.isPrinting()
-    assert not comm.isPaused()
-    assert not comm.isError()
-    assert not comm.isClosedOrError()
+    assert comm.getState() == _comm.PRINTER_STATE['CONNECTING']
     assert comm._printer_uri == printer['uri']
 
 
@@ -66,12 +56,7 @@ def test_printer_connect_get_authentise_printer_no_put(comm, printer, mocker):
 
     comm.connect(port="/dev/tty.derp", baudrate=250000)
 
-    assert comm.isOperational()
-    assert not comm.isBusy()
-    assert not comm.isPrinting()
-    assert not comm.isPaused()
-    assert not comm.isError()
-    assert not comm.isClosedOrError()
+    assert comm.getState() == _comm.PRINTER_STATE['CONNECTING']
     assert comm._printer_uri == printer['uri']
 
 @pytest.mark.parametrize("command_queue, response, current_time, expected_return, expected_queue", [
@@ -319,7 +304,7 @@ def test_readline(comm, httpretty, mocker, command_queue, response, current_time
     ('ok T:70 /190 B:30 /100 T0:70 /190 T1:90 /210', {'tools': [{'actual':70, 'target':190}, {'actual':90, 'target':210}], 'bed':{'actual':30, 'target':100}}),
     ('ok', None),
     ('something that isnt gcode', None),
-    ('ok, T:7.Nooope', None),
+    ('ok T:7.Nooope', None),
     ('ok T:219.0 /220.0 T0:219.0 /220.0 @:72 B@:0', {'tools': [{'actual':219.0, 'target':220}], 'bed':None}),
 ])
 def test_parse_temps(line, expected):
@@ -327,4 +312,4 @@ def test_parse_temps(line, expected):
     assert actual == expected
 
 def test_get_printer_status(comm, connect_printer): #pylint: disable=unused-argument
-    comm._get_printer_status()
+    comm._update_printer_data()

--- a/tests/test_comm.py
+++ b/tests/test_comm.py
@@ -588,3 +588,12 @@ def test_update_state(response, expected_state, comm):
 def test_update_progress(response, expected_progress, comm, assert_almost_equal):
     comm._update_progress(response)
     assert_almost_equal(comm._print_progress, expected_progress)
+
+@pytest.mark.parametrize("response, expected_temps", [
+    ({'nozzle_temperature':0}, {0: [0, None]}),
+    ({'nozzle_temperature':180.9}, {0: [180.9, None]}),
+])
+def test_update_temps(response, expected_temps, comm):
+    comm._update_temps(response)
+    assert comm._tool_tempuratures == expected_temps
+    assert comm._bed_tempurature == None

--- a/tests/test_comm.py
+++ b/tests/test_comm.py
@@ -17,8 +17,10 @@ def test_printer_connect_create_authentise_printer(comm, printer, httpretty, moc
     httpretty.register_uri(httpretty.POST, printer['request_url'],
                            adding_headers={"Location": printer['uri']})
 
-    # keep authentise from actually starting
-    mocker.patch("octoprint_authentise.helpers.run_client")
+    # keep authentise and monitoring threads from actually starting
+    mocker.patch('octoprint_authentise.comm.threading.Thread')
+    mocker.patch('octoprint_authentise.comm.RepeatedTimer')
+    mocker.patch("octoprint_authentise.comm.helpers.run_client")
 
     comm.connect(port="1234", baudrate=5678)
 
@@ -39,8 +41,10 @@ def test_printer_connect_get_authentise_printer(comm, printer, httpretty, mocker
     httpretty.register_uri(httpretty.PUT, printer['uri'])
 
 
-    # keep authentise from actually starting
-    mocker.patch("octoprint_authentise.helpers.run_client")
+    # keep authentise and monitoring threads from actually starting
+    mocker.patch('octoprint_authentise.comm.threading.Thread')
+    mocker.patch('octoprint_authentise.comm.RepeatedTimer')
+    mocker.patch("octoprint_authentise.comm.helpers.run_client")
 
     comm.connect(port="/dev/tty.derp", baudrate=5678)
 
@@ -55,8 +59,10 @@ def test_printer_connect_get_authentise_printer(comm, printer, httpretty, mocker
 
 # tests case in which port and baud rate are just right
 def test_printer_connect_get_authentise_printer_no_put(comm, printer, mocker):
-    # keep authentise from actually starting
-    mocker.patch("octoprint_authentise.helpers.run_client")
+    # keep authentise and monitoring threads from actually starting
+    mocker.patch('octoprint_authentise.comm.threading.Thread')
+    mocker.patch('octoprint_authentise.comm.RepeatedTimer')
+    mocker.patch("octoprint_authentise.comm.helpers.run_client")
 
     comm.connect(port="/dev/tty.derp", baudrate=250000)
 
@@ -319,3 +325,6 @@ def test_readline(comm, httpretty, mocker, command_queue, response, current_time
 def test_parse_temps(line, expected):
     actual = _comm.parse_temps(line)
     assert actual == expected
+
+def test_get_printer_status(comm, connect_printer): #pylint: disable=unused-argument
+    comm._get_printer_status()


### PR DESCRIPTION
Add in printer status updates by polling authentise.

This moves the temperature polling from sending gcode to just getting the temp from the current printer status, which will be uptodate if the printer is currently online (connected to authentiise).

This also adds tests for the majority of the comm object, putting is at close to 100% test coverage for it.